### PR TITLE
fix: Security CORS 설정 추가

### DIFF
--- a/src/main/java/com/project/stock/investory/config/SecurityConfig.java
+++ b/src/main/java/com/project/stock/investory/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.Customizer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -32,6 +33,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 // CSRF, 기본 폼로그인, HTTP Basic 비활성화 (우리는 JWT 사용)
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())


### PR DESCRIPTION
- SecurityFilterChain에 .cors(Customizer.withDefaults()) 추가
- 기존 CorsConfig(WebMvcConfigurer)에서 설정한 CORS 정책이 Security 레벨에도 적용되도록 수정
- 프론트(Vue) 개발 서버에서 API 호출 시 발생하던 CORS 에러 해결