### PR TITLE
feat: Refresh Token 재발급 로직 구현 및 저장 처리

### DIFF
--- a/src/main/java/com/project/stock/investory/comment/model/Comment.java
+++ b/src/main/java/com/project/stock/investory/comment/model/Comment.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -47,11 +49,11 @@ public class Comment {
     private Integer likeCount;
 
     // 작성일
-    @CreatedDate
+    @CreationTimestamp
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
+    @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/project/stock/investory/config/SecurityConfig.java
+++ b/src/main/java/com/project/stock/investory/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
                                 "/users/signup", "/users/login", "/oauth2/**", "/alarm/**",
                                 "/users/password-reset/send-code",
                                 "/users/password-reset/verify-code",
-                                "/users/password-reset/reset"
+                                "/users/password-reset/reset",
+                                "/users/refresh"
                         ).permitAll()
 
                         // stock 관련 GET 요청은 전체 공개

--- a/src/main/java/com/project/stock/investory/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/stock/investory/security/jwt/JwtUtil.java
@@ -14,6 +14,8 @@ public class JwtUtil {
 
     private final Key key; // JWT 서명(Signature)용 비밀키
     private static final long EXPIRATION_MS = 1000 * 60 * 60; // 1시간
+    // RefreshToken 만료 기간
+    private static final long REFRESH_EXPIRATION_MS = 1000L * 60 * 60 * 24 * 14;
 
     // application.properties에서 jwt.secret 값을 주입받음
     public JwtUtil(@Value("${jwt.secret}") String secretKey) {
@@ -70,5 +72,20 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public String generateRefreshToken(Long userId, String email, String name) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("name", name)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRATION_MS))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return validateToken(token);
     }
 }

--- a/src/main/java/com/project/stock/investory/user/controller/UserController.java
+++ b/src/main/java/com/project/stock/investory/user/controller/UserController.java
@@ -33,6 +33,14 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    // 토큰 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRefreshResponseDto> refresh(@RequestBody RefreshTokenRequestDto request) {
+        TokenRefreshResponseDto response = userService.refreshToken(request.getRefreshToken());
+        return ResponseEntity.ok(response);
+    }
+
+
     // 마이페이지 - 회원정보 조회
     @GetMapping("/me")
     public ResponseEntity<UserResponseDto> getMyPage(@AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/project/stock/investory/user/dto/CommentSimpleResponseDto.java
+++ b/src/main/java/com/project/stock/investory/user/dto/CommentSimpleResponseDto.java
@@ -3,9 +3,12 @@ package com.project.stock.investory.user.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class CommentSimpleResponseDto {
     private Long commentId;  // 댓글 ID
     private String content;  // 댓글 내용
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/project/stock/investory/user/dto/PostSimpleResponseDto.java
+++ b/src/main/java/com/project/stock/investory/user/dto/PostSimpleResponseDto.java
@@ -3,9 +3,12 @@ package com.project.stock.investory.user.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class PostSimpleResponseDto {
     private Long postId;
     private String title;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/project/stock/investory/user/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/project/stock/investory/user/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,8 @@
+package com.project.stock.investory.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/project/stock/investory/user/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/project/stock/investory/user/dto/TokenRefreshResponseDto.java
@@ -1,0 +1,11 @@
+package com.project.stock.investory.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenRefreshResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/project/stock/investory/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/project/stock/investory/user/dto/UserLoginResponseDto.java
@@ -12,4 +12,5 @@ public class UserLoginResponseDto {
     private String email;
     private String name;
     private String accessToken;  // JWT 토큰 반환
+    private String refreshToken;
 }

--- a/src/main/java/com/project/stock/investory/user/entity/User.java
+++ b/src/main/java/com/project/stock/investory/user/entity/User.java
@@ -36,6 +36,9 @@ public class User {
     @Builder.Default
     private Integer isSocial = 0;  // 소셜 로그인 여부 (0: 일반, 1: 소셜)
 
+    @Column(name = "refresh_token", length = 512, nullable = true)
+    private String refreshToken; // 리프레시 토큰
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt; // 가입일 (자동 생성)
@@ -60,6 +63,14 @@ public class User {
     // 탈퇴 처리 (soft delete)
     public void withdraw() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void clearRefreshToken() {
+        this.refreshToken = null;
     }
 
 }

--- a/src/main/java/com/project/stock/investory/user/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/project/stock/investory/user/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.project.stock.investory.user.exception;
+
+import com.project.stock.investory.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRefreshTokenException extends BusinessException {
+    public InvalidRefreshTokenException() {
+        super("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/project/stock/investory/user/service/EmailService.java
+++ b/src/main/java/com/project/stock/investory/user/service/EmailService.java
@@ -1,7 +1,7 @@
 package com.project.stock.investory.user.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,8 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
 
-    private final String fromEmail = "yeeun22152215@gmail.com"; // 하드코딩 수정 예정
+    @Value("${mail.from}")
+    private String fromEmail;
 
     public void sendEmail(String to, String subject, String text) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/com/project/stock/investory/user/service/UserService.java
+++ b/src/main/java/com/project/stock/investory/user/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -99,7 +100,7 @@ public class UserService {
     }
 
     // 로그인
-    @Transactional(readOnly = true)
+    @Transactional
     public UserLoginResponseDto login(UserLoginRequestDto request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(UserNotFoundException::new);
@@ -116,16 +117,50 @@ public class UserService {
             throw new InvalidPasswordException();
         }
 
-        // 로그인 성공 → JWT 토큰 발급
-        String token = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName());
+        // AccessToken 생성
+        String accessToken  = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName());
+
+        // RefreshToken 생성
+        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), user.getEmail(), user.getName());
+
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
 
         return UserLoginResponseDto.builder()
                 .userId(user.getUserId())
                 .email(user.getEmail())
                 .name(user.getName())
-                .accessToken(token)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
+
+    @Transactional
+    public TokenRefreshResponseDto refreshToken(String refreshToken) {
+        if (!jwtUtil.validateRefreshToken(refreshToken)) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // DB에 저장된 refreshToken과 비교
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        String newAccessToken = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName());
+        String newRefreshToken = jwtUtil.generateRefreshToken(user.getUserId(), user.getEmail(), user.getName());
+
+        user.updateRefreshToken(newRefreshToken);
+
+        return TokenRefreshResponseDto.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
 
     // 내 정보 조회 (마이페이지 조회)
     @Transactional(readOnly = true)
@@ -236,6 +271,7 @@ public class UserService {
                 .map(comment -> CommentSimpleResponseDto.builder()
                         .commentId(comment.getCommentId())
                         .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
                         .build())
                 .toList();
     }
@@ -249,6 +285,7 @@ public class UserService {
                 .map(like -> CommentSimpleResponseDto.builder()
                         .commentId(like.getComment().getCommentId())
                         .content(like.getComment().getContent())
+                        .createdAt(like.getComment().getCreatedAt())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/project/stock/investory/user/service/UserService.java
+++ b/src/main/java/com/project/stock/investory/user/service/UserService.java
@@ -208,6 +208,7 @@ public class UserService {
                 .map(post -> PostSimpleResponseDto.builder()
                         .postId(post.getPostId())
                         .title(post.getTitle())
+                        .createdAt(post.getCreatedAt())
                         .build())
                 .toList();
     }
@@ -221,6 +222,7 @@ public class UserService {
                 .map(like -> PostSimpleResponseDto.builder()
                         .postId(like.getPost().getPostId())
                         .title(like.getPost().getTitle())
+                        .createdAt(like.getCreatedAt())
                         .build())
                 .toList();
     }


### PR DESCRIPTION
- 로그인 시 Refresh Token 발급 후 DB에 저장하도록 UserService 수정
- refreshToken API 추가 (/users/refresh)
- JwtUtil에 refresh token 생성, 검증 로직 구현
- SecurityConfig에서 /users/refresh 경로 permitAll 처리
- 기존 로그인, 마이페이지 인증 로직 정상 동작 확인
