### PR TITLE
feat: 주가 이력 데이터 저장 API 개발 및 데이터 적재 로직 개선

### DIFF
--- a/src/main/java/com/project/stock/investory/config/SecurityConfig.java
+++ b/src/main/java/com/project/stock/investory/config/SecurityConfig.java
@@ -56,6 +56,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/stock/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/stock/*/analytics/**").permitAll()
 
+                        // stock save api - test code
+                        .requestMatchers(HttpMethod.POST, "/stock/save/**").permitAll()
+
                         // 🔹 SSE 스트림 엔드포인트 공개 (추가)
                         .requestMatchers(HttpMethod.GET, "/api/stock/*/stream").permitAll()
 

--- a/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
+++ b/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
@@ -1,26 +1,90 @@
 package com.project.stock.investory.mainData.controller;
 
 import com.project.stock.investory.mainData.dto.StockPriceDto;
+import com.project.stock.investory.mainData.dto.StockPriceHistoryDto;
+import com.project.stock.investory.mainData.service.StockPriceHistoryService;
+import com.project.stock.investory.mainData.service.StockPriceSaveService;
 import com.project.stock.investory.mainData.service.StockPriceService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 @RestController
+@RequestMapping("/stock")
+@Slf4j
 public class StockPriceController {
     private final StockPriceService stockPriceService;
+    private final StockPriceHistoryService stockPriceHistoryService;
+    private final StockPriceSaveService stockPriceSaveService;
 
-    public StockPriceController(StockPriceService stockPriceService) {
+    public StockPriceController(StockPriceService stockPriceService, StockPriceHistoryService stockPriceHistoryService, StockPriceSaveService stockPriceSaveService) {
         this.stockPriceService = stockPriceService;
+        this.stockPriceHistoryService = stockPriceHistoryService;
+        this.stockPriceSaveService = stockPriceSaveService;
     }
 
-    @GetMapping("/stock/{iscd}/price")
-    public StockPriceDto getPrice(@PathVariable String iscd, Model model) {
-        Mono<StockPriceDto> response = stockPriceService.getStockPrice(iscd);
+    // 하루 가격
+    @GetMapping("/{stockId}/price")
+    public StockPriceDto getPrice(@PathVariable String stockId, Model model) {
+        Mono<StockPriceDto> response = stockPriceService.getStockPrice(stockId);
 
         return response.block();
+    }
+
+
+    /**
+     * 주식 가격 이력 조회 API
+     */
+    // 30영업일 가격 가져오기
+    @GetMapping("/{stockId}/history")
+    public List<StockPriceHistoryDto> getStockPriceHistory(
+            @PathVariable String stockId,
+            @RequestParam String period
+    ) {
+
+        return stockPriceHistoryService.getStockPriceHistory(stockId, period);
+    }
+
+
+    // 가격 데이터 조회 및 저장 엔드포인트
+    @PostMapping("/{stockId}/history/save")
+    public ResponseEntity<String> fetchAndSaveStockPriceHistory(
+                                                                 @PathVariable String stockId,
+                                                                 @RequestParam String period
+    ) {
+        System.out.println("API 호출 시작: stockId=" + stockId + ", period=" + period); // 요청 시작 로그
+
+        try {
+            // 1. API에서 데이터 받아오기
+            List<StockPriceHistoryDto> dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, period);
+
+            if (dtoList == null || dtoList.isEmpty()) {
+                System.out.println("API로부터 받아온 데이터가 없거나 비어 있습니다. 저장 작업을 건너뜜.");
+                return new ResponseEntity<>("데이터를 찾을 수 없거나 비어있어 저장하지 않았습니다.", HttpStatus.NOT_FOUND); // 404 응답
+            }
+
+            System.out.println("API로부터 " + dtoList.size() + "개의 데이터 수신: " + dtoList); // 수신 데이터 로그
+
+            // 2. 저장 서비스 호출
+            stockPriceSaveService.saveAll(dtoList, stockId);
+            System.out.println("데이터베이스 저장 완료."); // 저장 완료 로그
+
+            return new ResponseEntity<>("주가 이력 데이터 저장 성공", HttpStatus.OK); // 200 OK 응답
+
+        } catch (RuntimeException e) { // 서비스 계층에서 던진 RuntimeException 캐치
+            System.err.println("API 호출 또는 데이터 저장 중 오류 발생: " + e.getMessage());
+            e.printStackTrace(); // 상세 스택 트레이스 출력 (디버깅용)
+            return new ResponseEntity<>("주가 이력 데이터 저장 실패: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR); // 500 에러 응답
+        } catch (Exception e) { // 그 외 예상치 못한 모든 예외 캐치
+            System.err.println("예상치 못한 오류 발생: " + e.getMessage());
+            e.printStackTrace();
+            return new ResponseEntity<>("예상치 못한 서버 오류: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR); // 500 에러 응답
+        }
     }
 
 }

--- a/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
+++ b/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
@@ -2,13 +2,14 @@ package com.project.stock.investory.mainData.controller;
 
 import com.project.stock.investory.mainData.dto.StockPriceDto;
 import com.project.stock.investory.mainData.dto.StockPriceHistoryDto;
+import com.project.stock.investory.mainData.dto.StockPriceHistoryResponseDto;
 import com.project.stock.investory.mainData.service.StockPriceHistoryService;
 import com.project.stock.investory.mainData.service.StockPriceSaveService;
 import com.project.stock.investory.mainData.service.StockPriceService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -28,9 +29,9 @@ public class StockPriceController {
         this.stockPriceSaveService = stockPriceSaveService;
     }
 
-    // 하루 가격
+    // get 하루 실시간 가격
     @GetMapping("/{stockId}/price")
-    public StockPriceDto getPrice(@PathVariable String stockId, Model model) {
+    public StockPriceDto getPrice(@PathVariable String stockId) {
         Mono<StockPriceDto> response = stockPriceService.getStockPrice(stockId);
 
         return response.block();
@@ -38,10 +39,41 @@ public class StockPriceController {
 
 
     /**
-     * 주식 가격 이력 조회 API
+     * [price history api]
+     * 1. DB의 stock price history 조회
+     * 2. 100영업일 데이터 가져오기
+     * 3. 데이터 save api
+     * 4. 티커별 데이터 save api
      */
-    // 30영업일 가격 가져오기
+    @Operation(summary = "DB의 stock price history 조회")
     @GetMapping("/{stockId}/history")
+    public ResponseEntity<List<StockPriceHistoryResponseDto>> getStockPriceHistoryByTicker(@PathVariable String stockId) {
+        try {
+            // 서비스 계층의 메서드를 호출하여 데이터 조회
+            List<StockPriceHistoryResponseDto> history = stockPriceSaveService.getStockHistoryByTicker(stockId); // 서비스 메서드 호출
+
+            // 데이터가 없는 경우 404 Not Found 반환
+            if (history.isEmpty()) {
+                // 로그를 추가하여 어떤 데이터가 없는지 추적하는 게 좋습니다.
+                System.out.println("No stock price history found for stockId: " + stockId);
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+
+            // 조회된 데이터를 200 OK와 함께 반환
+            return new ResponseEntity<>(history, HttpStatus.OK);
+
+        } catch (Exception e) {
+            // 예외 발생 시 500 Internal Server Error 반환 및 에러 로깅
+            System.err.println("Error fetching stock price history for stockId " + stockId + ": " + e.getMessage());
+            e.printStackTrace(); // 디버깅을 위해 스택 트레이스 출력
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+    // 100개 가격 가져오기
+    @Operation(summary = "100개 가격 가져오기")
+    @GetMapping("/api/{stockId}/history")
     public List<StockPriceHistoryDto> getStockPriceHistory(
             @PathVariable String stockId,
             @RequestParam String period
@@ -51,27 +83,28 @@ public class StockPriceController {
     }
 
 
-    // 가격 데이터 조회 및 저장 엔드포인트
-    @PostMapping("/{stockId}/history/save")
+    // 가격 데이터 조회 및 save
+    @Operation(summary = "가격 데이터 조회 및 save")
+    @PostMapping("/save/{stockId}")
     public ResponseEntity<String> fetchAndSaveStockPriceHistory(
-                                                                 @PathVariable String stockId,
-                                                                 @RequestParam String period
+            @PathVariable String stockId,
+            @RequestParam String period
     ) {
         System.out.println("API 호출 시작: stockId=" + stockId + ", period=" + period); // 요청 시작 로그
 
         try {
-            // 1. API에서 데이터 받아오기
-            List<StockPriceHistoryDto> dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, period);
-
-            if (dtoList == null || dtoList.isEmpty()) {
-                System.out.println("API로부터 받아온 데이터가 없거나 비어 있습니다. 저장 작업을 건너뜜.");
-                return new ResponseEntity<>("데이터를 찾을 수 없거나 비어있어 저장하지 않았습니다.", HttpStatus.NOT_FOUND); // 404 응답
-            }
-
-            System.out.println("API로부터 " + dtoList.size() + "개의 데이터 수신: " + dtoList); // 수신 데이터 로그
+//            // 1. API에서 데이터 받아오기
+//            List<StockPriceHistoryDto> dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, period);
+//
+//            if (dtoList == null || dtoList.isEmpty()) {
+//                System.out.println("API로부터 받아온 데이터가 없거나 비어 있습니다. 저장 작업을 건너뜜.");
+//                return new ResponseEntity<>("데이터를 찾을 수 없거나 비어있어 저장하지 않았습니다.", HttpStatus.NOT_FOUND); // 404 응답
+//            }
+//
+//            System.out.println("API로부터 " + dtoList.size() + "개의 데이터 수신: " + dtoList); // 수신 데이터 로그
 
             // 2. 저장 서비스 호출
-            stockPriceSaveService.saveAll(dtoList, stockId);
+            stockPriceSaveService.saveAll(stockId, period);
             System.out.println("데이터베이스 저장 완료."); // 저장 완료 로그
 
             return new ResponseEntity<>("주가 이력 데이터 저장 성공", HttpStatus.OK); // 200 OK 응답
@@ -84,6 +117,18 @@ public class StockPriceController {
             System.err.println("예상치 못한 오류 발생: " + e.getMessage());
             e.printStackTrace();
             return new ResponseEntity<>("예상치 못한 서버 오류: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR); // 500 에러 응답
+        }
+    }
+
+
+    @PostMapping("/save/all")
+    public String saveAllTicker(@RequestParam String period) {
+        try {
+            stockPriceSaveService.saveAllTicker(period);
+            return "모든 종목 데이터 저장 완료";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "저장 실패: " + e.getMessage();
         }
     }
 

--- a/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
+++ b/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
@@ -71,8 +71,8 @@ public class StockPriceController {
     }
 
 
-    // 100개 가격 가져오기
-    @Operation(summary = "100개 가격 가져오기")
+    // get 특정 종목 100개 가격 데이터
+    @Operation(summary = "get 특정 종목 100개 가격 데이터 ")
     @GetMapping("/api/{stockId}/history")
     public List<StockPriceHistoryDto> getStockPriceHistory(
             @PathVariable String stockId,
@@ -83,8 +83,8 @@ public class StockPriceController {
     }
 
 
-    // 가격 데이터 조회 및 save
-    @Operation(summary = "가격 데이터 조회 및 save")
+    // 특정 종목 가격 데이터 조회 및 save
+    @Operation(summary = "특정 종목 가격 데이터 조회 및 save")
     @PostMapping("/save/{stockId}")
     public ResponseEntity<String> fetchAndSaveStockPriceHistory(
             @PathVariable String stockId,
@@ -93,17 +93,6 @@ public class StockPriceController {
         System.out.println("API 호출 시작: stockId=" + stockId + ", period=" + period); // 요청 시작 로그
 
         try {
-//            // 1. API에서 데이터 받아오기
-//            List<StockPriceHistoryDto> dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, period);
-//
-//            if (dtoList == null || dtoList.isEmpty()) {
-//                System.out.println("API로부터 받아온 데이터가 없거나 비어 있습니다. 저장 작업을 건너뜜.");
-//                return new ResponseEntity<>("데이터를 찾을 수 없거나 비어있어 저장하지 않았습니다.", HttpStatus.NOT_FOUND); // 404 응답
-//            }
-//
-//            System.out.println("API로부터 " + dtoList.size() + "개의 데이터 수신: " + dtoList); // 수신 데이터 로그
-
-            // 2. 저장 서비스 호출
             stockPriceSaveService.saveAll(stockId, period);
             System.out.println("데이터베이스 저장 완료."); // 저장 완료 로그
 
@@ -121,6 +110,8 @@ public class StockPriceController {
     }
 
 
+    // 여러 티커 가져와서 가격 데이터 저장
+    @Operation(summary = "여러 티커 가져와서 가격 데이터 저장")
     @PostMapping("/save/all")
     public String saveAllTicker(@RequestParam String period) {
         try {

--- a/src/main/java/com/project/stock/investory/mainData/dto/StockPriceHistoryDto.java
+++ b/src/main/java/com/project/stock/investory/mainData/dto/StockPriceHistoryDto.java
@@ -1,10 +1,14 @@
 package com.project.stock.investory.mainData.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.project.stock.investory.mainData.entity.StockPriceHistory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @Data
 @NoArgsConstructor
@@ -62,4 +66,54 @@ public class StockPriceHistoryDto {
     // 재발행 사유 (공란 가능)
     @JsonProperty("revl_issu_reas")
     private String revlIssuReas;
+
+
+    /**
+     * DTO를 Entity로 변환하는 메서드
+     *
+     * @param stockId 저장할 종목코드 (외래키)
+     * @return StockPriceHistory Entity
+     */
+    public StockPriceHistory toEntity(String stockId) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        return StockPriceHistory.builder()
+                .stockId(stockId)
+                .tradeDate(LocalDate.parse(this.stckBsopDate, formatter))
+                .openPrice(parseInteger(this.stckOprc))
+                .closePrice(parseInteger(this.stckClpr))
+                .highPrice(parseInteger(this.stckHgpr))
+                .lowPrice(parseInteger(this.stckLwpr))
+                .volume(parseLong(this.acmlVol))
+                .build();
+    }
+
+    // String을 Integer로 안전하게 파싱하는 헬퍼 메서드
+    private Integer parseInteger(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            System.err.println("Integer 파싱 오류: " + value);
+            return null;
+        }
+    }
+
+    // String을 Long으로 안전하게 파싱하는 헬퍼 메서드
+    private Long parseLong(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            System.err.println("Long 파싱 오류: " + value);
+            return null;
+        }
+    }
+
+
 }

--- a/src/main/java/com/project/stock/investory/mainData/dto/StockPriceHistoryDto.java
+++ b/src/main/java/com/project/stock/investory/mainData/dto/StockPriceHistoryDto.java
@@ -1,0 +1,65 @@
+package com.project.stock.investory.mainData.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockPriceHistoryDto {
+    // 거래일자 (예: "20250131")
+    @JsonProperty("stck_bsop_date")
+    private String stckBsopDate;
+
+    // 종가
+    @JsonProperty("stck_clpr")
+    private String stckClpr;
+
+    // 시가
+    @JsonProperty("stck_oprc")
+    private String stckOprc;
+
+    // 고가
+    @JsonProperty("stck_hgpr")
+    private String stckHgpr;
+
+    // 저가
+    @JsonProperty("stck_lwpr")
+    private String stckLwpr;
+
+    // 누적 거래량
+    @JsonProperty("acml_vol")
+    private String acmlVol;
+
+    // 누적 거래대금
+    @JsonProperty("acml_tr_pbmn")
+    private String acmlTrPbmn;
+
+    // 플로팅 클래스 코드
+    @JsonProperty("flng_cls_code")
+    private String flngClsCode;
+
+    // 배당률
+    @JsonProperty("prtt_rate")
+    private String prttRate;
+
+    // 수정여부
+    @JsonProperty("mod_yn")
+    private String modYn;
+
+    // 전일 대비 부호 (상승/하락 등)
+    @JsonProperty("prdy_vrss_sign")
+    private String prdyVrssSign;
+
+    // 전일 대비 가격
+    @JsonProperty("prdy_vrss")
+    private String prdyVrss;
+
+    // 재발행 사유 (공란 가능)
+    @JsonProperty("revl_issu_reas")
+    private String revlIssuReas;
+}

--- a/src/main/java/com/project/stock/investory/mainData/dto/StockPriceHistoryResponseDto.java
+++ b/src/main/java/com/project/stock/investory/mainData/dto/StockPriceHistoryResponseDto.java
@@ -1,0 +1,54 @@
+package com.project.stock.investory.mainData.dto;
+
+import com.project.stock.investory.mainData.entity.StockPriceHistory;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockPriceHistoryResponseDto {
+
+    private Long id;
+    // 티커
+    private String stockId;
+    // 거래일
+    private LocalDate tradeDate;
+    // 시가
+    private Integer openPrice;
+    // 종가
+    private Integer closePrice;
+    // 고가
+    private Integer highPrice;
+    // 저가
+    private Integer lowPrice;
+    // 거래량
+    private Long volume;
+
+    /**
+     * StockPriceHistory Entity 객체를 StockPriceHistoryResponseDto 객체로 변환
+     * 이 메서드는 엔티티에서 필요한 필드들을 DTO로 복사하는 역할을 합니다.
+     *
+     * @param entity 변환할 StockPriceHistory 엔티티
+     * @return 변환된 StockPriceHistoryResponseDto
+     */
+    public static StockPriceHistoryResponseDto fromEntity(StockPriceHistory entity) {
+        if (entity == null) {
+            return null; // 또는 빈 DTO를 반환하는 등의 예외 처리
+        }
+        return StockPriceHistoryResponseDto.builder()
+                .id(entity.getId())
+                .stockId(entity.getStockId())
+                .tradeDate(entity.getTradeDate())
+                .openPrice(entity.getOpenPrice())
+                .closePrice(entity.getClosePrice())
+                .highPrice(entity.getHighPrice())
+                .lowPrice(entity.getLowPrice())
+                .volume(entity.getVolume())
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/stock/investory/mainData/entity/StockPriceHistory.java
+++ b/src/main/java/com/project/stock/investory/mainData/entity/StockPriceHistory.java
@@ -1,0 +1,51 @@
+package com.project.stock.investory.mainData.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+
+@Entity
+@Table(name = "stock_price")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockPriceHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "stock_history_generator")
+    @SequenceGenerator(name = "stock_history_generator", sequenceName = "stock_history", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    // Stock 테이블 외래키 (예: stock_id)
+    @Column(name = "stock_id", nullable = false)
+    private String stockId;
+
+    // 거래일자 (DATE 타입)
+    @Column(name = "trade:date", nullable = false)
+    private LocalDate tradeDate;
+
+    // 시가
+    @Column(name = "open_price")
+    private Integer openPrice;
+
+    // 종가
+    @Column(name = "close_price")
+    private Integer closePrice;
+
+    // 고가
+    @Column(name = "high_price")
+    private Integer highPrice;
+
+    // 저가
+    @Column(name = "low_price")
+    private Integer lowPrice;
+
+    // 거래량
+    @Column(name = "volume")
+    private Long volume;
+}

--- a/src/main/java/com/project/stock/investory/mainData/entity/StockPriceHistory.java
+++ b/src/main/java/com/project/stock/investory/mainData/entity/StockPriceHistory.java
@@ -26,7 +26,7 @@ public class StockPriceHistory {
     private String stockId;
 
     // 거래일자 (DATE 타입)
-    @Column(name = "trade:date", nullable = false)
+    @Column(name = "trade_date", nullable = false)
     private LocalDate tradeDate;
 
     // 시가

--- a/src/main/java/com/project/stock/investory/mainData/repository/StockPriceHistoryRepository.java
+++ b/src/main/java/com/project/stock/investory/mainData/repository/StockPriceHistoryRepository.java
@@ -3,6 +3,22 @@ package com.project.stock.investory.mainData.repository;
 
 import com.project.stock.investory.mainData.entity.StockPriceHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StockPriceHistoryRepository extends JpaRepository<StockPriceHistory, Long> {
+
+    // 특정 주식 ID (ticker)에 해당하는 모든 주가 이력 데이터 조회
+    List<StockPriceHistory> findByStockId(String stockId);
+
+    // 가장 과거의 거래일 조회 (네이티브 쿼리 사용)
+    @Query(value = """
+            SELECT TO_CHAR(MIN(trade_date), 'YYYYMMDD')
+            FROM stock_price
+            WHERE stock_id = :stockId
+            """, nativeQuery = true)
+    String findOldestTradeDateByStockId(@Param("stockId") String stockId);
+
 }

--- a/src/main/java/com/project/stock/investory/mainData/repository/StockPriceHistoryRepository.java
+++ b/src/main/java/com/project/stock/investory/mainData/repository/StockPriceHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.project.stock.investory.mainData.repository;
+
+
+import com.project.stock.investory.mainData.entity.StockPriceHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockPriceHistoryRepository extends JpaRepository<StockPriceHistory, Long> {
+}

--- a/src/main/java/com/project/stock/investory/mainData/scheduler/StockPriceHistoryScheduler.java
+++ b/src/main/java/com/project/stock/investory/mainData/scheduler/StockPriceHistoryScheduler.java
@@ -1,0 +1,4 @@
+package com.project.stock.investory.mainData.scheduler;
+
+public class StockPriceHistoryScheduler {
+}

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
@@ -1,0 +1,101 @@
+package com.project.stock.investory.mainData.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.stock.investory.mainData.dto.StockPriceHistoryDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class StockPriceHistoryService {
+
+    // 인증 정보
+    @Value("${appkey}")
+    private String appkey;
+
+    @Value("${appsecret}")
+    private String appSecret;
+
+    @Value("${access_token}")
+    private String accessToken;
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public StockPriceHistoryService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder.baseUrl("https://openapi.koreainvestment.com:9443").build();
+        this.objectMapper = objectMapper;
+    }
+
+    // HTTP 헤더 생성
+    private HttpHeaders createHistoryHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(accessToken);
+        headers.set("appkey", appkey);
+        headers.set("appsecret", appSecret);
+        headers.set("tr_id", "FHKST03010100"); // 주식현재가 시세 TR ID
+        return headers;
+    }
+
+    /**
+     * 주식 가격 이력 조회
+     *
+     * @param stockId 종목코드 (예: "005930")
+     * @param period  기간 타입 (D:일봉, W:주봉, M:월봉)
+     * @return StockPriceHistroyDto 리스트
+     */
+    public List<StockPriceHistoryDto> getStockPriceHistory(
+            String stockId,
+            String period
+    ) {
+        HttpHeaders headers = createHistoryHeaders();
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice")
+                        .queryParam("fid_cond_mrkt_div_code", "J") // J: 주식
+                        .queryParam("fid_input_iscd", stockId) // J: 주식
+                        .queryParam("fid_input_date_1", "20220101") // J: 주식
+                        .queryParam("fid_input_date_2", period)
+                        .queryParam("fid_period_div_code", "D")
+                        .queryParam("fid_org_adj_prc", "1")
+                        .build())
+                .headers(httpHeaders -> httpHeaders.addAll(headers))
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMap(this::parseHistoryData)
+                .block();
+    }
+
+    // 응답 데이터 파싱
+    private Mono<List<StockPriceHistoryDto>> parseHistoryData(String response) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(response);
+            JsonNode outputNode = rootNode.get("output2");
+
+            List<StockPriceHistoryDto> historyList = new ArrayList<>();
+
+            if (outputNode != null && outputNode.isArray()) {
+                for (JsonNode node : outputNode) {
+                    StockPriceHistoryDto dto = objectMapper.treeToValue(node, StockPriceHistoryDto.class);
+                    historyList.add(dto);
+                }
+            }
+
+            return Mono.just(historyList);
+
+        } catch (Exception e) {
+            return Mono.error(new RuntimeException("주가 이력 데이터 파싱 실패", e));
+        }
+    }
+}

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
@@ -64,10 +64,10 @@ public class StockPriceHistoryService {
                 .uri(uriBuilder -> uriBuilder
                         .path("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice")
                         .queryParam("fid_cond_mrkt_div_code", "J") // J: 주식
-                        .queryParam("fid_input_iscd", stockId) // J: 주식
-                        .queryParam("fid_input_date_1", "20220101") // J: 주식
+                        .queryParam("fid_input_iscd", stockId)
+                        .queryParam("fid_input_date_1", "20220101") // 가장 과거 데이터 하한 설정
                         .queryParam("fid_input_date_2", period)
-                        .queryParam("fid_period_div_code", "D")
+                        .queryParam("fid_period_div_code", "W") //  (D:일봉, W:주봉, M:월봉, Y:년봉)
                         .queryParam("fid_org_adj_prc", "1")
                         .build())
                 .headers(httpHeaders -> httpHeaders.addAll(headers))

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
@@ -65,10 +65,10 @@ public class StockPriceHistoryService {
                         .path("/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice")
                         .queryParam("fid_cond_mrkt_div_code", "J") // J: 주식
                         .queryParam("fid_input_iscd", stockId)
-                        .queryParam("fid_input_date_1", "20220101") // 가장 과거 데이터 하한 설정
+                        .queryParam("fid_input_date_1", "20000101") // 가장 과거 데이터 하한 설정
                         .queryParam("fid_input_date_2", period)
                         .queryParam("fid_period_div_code", "W") //  (D:일봉, W:주봉, M:월봉, Y:년봉)
-                        .queryParam("fid_org_adj_prc", "1")
+                        .queryParam("fid_org_adj_prc", "0") //  (0:수정주가 1:원주가)
                         .build())
                 .headers(httpHeaders -> httpHeaders.addAll(headers))
                 .retrieve()

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
@@ -1,8 +1,12 @@
 package com.project.stock.investory.mainData.service;
 
+import com.project.stock.investory.mainData.dto.RankDto;
 import com.project.stock.investory.mainData.dto.StockPriceHistoryDto;
+import com.project.stock.investory.mainData.dto.StockPriceHistoryResponseDto;
 import com.project.stock.investory.mainData.entity.StockPriceHistory;
 import com.project.stock.investory.mainData.repository.StockPriceHistoryRepository;
+import com.project.stock.investory.stockInfo.service.StockSaveService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,88 +14,155 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 public class StockPriceSaveService {
 
     private final StockPriceHistoryRepository stockPriceHistoryRepository;
+    private final StockPriceHistoryService stockPriceHistoryService;
+    private final RankService rankService;
+    private final StockSaveService stockSaveService;
 
     @Autowired
-    public StockPriceSaveService(StockPriceHistoryRepository stockPriceHistoryRepository) {
+    public StockPriceSaveService(StockPriceHistoryRepository stockPriceHistoryRepository,
+                                 StockPriceHistoryService stockPriceHistoryService,
+                                 RankService rankService,
+                                 StockSaveService stockSaveService) {
         this.stockPriceHistoryRepository = stockPriceHistoryRepository;
+        this.stockPriceHistoryService = stockPriceHistoryService;
+        this.rankService = rankService;
+        this.stockSaveService = stockSaveService;
+
     }
+
+
+    // 특정 티커 주가 데이터 get
+    public List<StockPriceHistoryResponseDto> getStockHistoryByTicker(String ticker) {
+        // Repository 메서드 호출
+        List<StockPriceHistory> entities = stockPriceHistoryRepository.findByStockId(ticker);
+
+        // 엔티티 리스트를 DTO 리스트로 변환하여 반환
+        return entities.stream()
+                .map(StockPriceHistoryResponseDto::fromEntity) // StockPriceHistoryDto에 fromEntity 메서드가 있다고 가정
+                .collect(Collectors.toList());
+    }
+
 
     /**
-     * 주가 이력 DTO 리스트를 받아 DB에 저장
-     *
-     * @param dtoList 주가 이력 DTO 리스트
-     * @param stockId 저장할 종목코드 (외래키)
+     * 1. 시가총액 기준 티커별 DB에 saveAllTicker
+     * 2. 주가 이력 DTO 리스트를 받아 DB에 saveAll
      */
-    @Transactional // 모든 저장이 하나의 트랜잭션으로 묶이도록 합니다. (중요!)
-    public void saveAll(List<StockPriceHistoryDto> dtoList, String stockId) {
-        if (dtoList == null || dtoList.isEmpty()) {
-            System.out.println("저장할 주가 이력 데이터가 없습니다.");
-            return;
-        }
 
-        List<StockPriceHistory> entitiesToSave = dtoList.stream()
-                .map(dto -> convertToEntity(dto, stockId)) // DTO를 Entity로 변환
-                .collect(java.util.stream.Collectors.toList());
+    // 1. 시가총액 기준 티커별 DB에 saveAllTicker
+    public void saveAllTicker(String period) {
+        List<RankDto> rankData = rankService.getRankData("5").block();
+        int i = 0;
 
-        try {
-            stockPriceHistoryRepository.saveAll(entitiesToSave);
-            System.out.println("총 " + entitiesToSave.size() + "개의 주가 이력 데이터 저장 완료.");
-        } catch (Exception e) {
-            System.err.println("주가 이력 데이터 저장 중 오류 발생: " + e.getMessage());
-            e.printStackTrace(); // 상세한 스택 트레이스 출력
-            // 필요하다면 예외를 다시 던지거나 특정 예외로 변환
-            throw new RuntimeException("데이터베이스 저장 실패", e);
-        }
+        System.out.println("실행 start");
+        long start = System.currentTimeMillis();
+        if (rankData != null) {
+            for (RankDto dto : rankData) {
+
+                String stockId = dto.getCode();
+                log.info("번호: {}, 종목: {}, 기준일자: {}", i, stockId, period);
+                i++;
+
+                saveAll(stockId, period);
+
+                // sleep
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    e.printStackTrace();
+                }
+            }
+        } // end if
+
+        long end = System.currentTimeMillis();
+        System.out.println("실행 시간(ms): " + (end - start));
     }
 
-    /**
-     * StockPriceHistoryDto를 StockPriceHistory Entity로 변환
-     */
-    private StockPriceHistory convertToEntity(StockPriceHistoryDto dto, String stockId) {
-        // 날짜 형식 지정: "YYYYMMDD"
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-        return StockPriceHistory.builder()
-                .stockId(stockId) // 컨트롤러에서 받은 stockId 사용
-                .tradeDate(LocalDate.parse(dto.getStckBsopDate(), formatter)) // String -> LocalDate 파싱
-                // 가격 정보는 String으로 오므로 Integer로 변환, 실패할 경우 0 또는 null 처리
-                .openPrice(parseInteger(dto.getStckOprc()))
-                .closePrice(parseInteger(dto.getStckClpr()))
-                .highPrice(parseInteger(dto.getStckHgpr()))
-                .lowPrice(parseInteger(dto.getStckLwpr()))
-                // 거래량은 Long으로 변환
-                .volume(parseLong(dto.getAcmlVol()))
-                .build();
-    }
+    // 2. 주가 이력 DTO 리스트를 받아 DB에 saveAll
+    @Transactional
+    public void saveAll(String stockId, String period) {
 
-    // String을 Integer로 안전하게 파싱하는 헬퍼 메서드
-    private Integer parseInteger(String value) {
-        if (value == null || value.trim().isEmpty()) {
-            return null; // 또는 0 (요구사항에 따라)
-        }
-        try {
-            return Integer.parseInt(value.trim());
-        } catch (NumberFormatException e) {
-            System.err.println("Integer 파싱 오류: " + value);
-            return null; // 또는 0
-        }
-    }
+        // API 조회를 시작할 현재 기간 (초기값은 initialPeriod)
+        String currentApiPeriod = period;
 
-    // String을 Long으로 안전하게 파싱하는 헬퍼 메서드
-    private Long parseLong(String value) {
-        if (value == null || value.trim().isEmpty()) {
-            return null; // 또는 0L (요구사항에 따라)
-        }
-        try {
-            return Long.parseLong(value.trim());
-        } catch (NumberFormatException e) {
-            System.err.println("Long 파싱 오류: " + value);
-            return null; // 또는 0L
-        }
+        // 목표로 하는 최종 날짜 (2022년 1월 1일)
+        // LocalDate.of(YYYY, MM, DD) 형태로 직접 LocalDate 객체를 생성합니다.
+        final LocalDate LAST_TARGET_DATE = LocalDate.of(2022, 1, 1);
+
+        boolean hasMoreDataFromApi = true; // API에서 더 가져올 데이터가 있는지 여부
+
+        do {
+            // 1. API에서 데이터 받아오기
+            List<StockPriceHistoryDto> dtoList;
+
+            try {
+                // 기간별 데이터 조회
+                log.info("종목: {}, 기준일자: {}", stockId, currentApiPeriod);
+                dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, currentApiPeriod);
+
+            } catch (Exception e) {
+                log.error("API 호출 중 오류 발생 (종목: {}, 기간: {}): {}", stockId, currentApiPeriod, e.getMessage(), e);
+                hasMoreDataFromApi = false;
+                throw new RuntimeException("API 데이터 조회 실패", e);
+            }
+
+            if (dtoList == null || dtoList.isEmpty()) {
+                log.info("API로부터 더 이상 받아올 데이터가 없습니다. 저장 작업을 종료합니다. 종목: {}, 마지막 조회 기간: {}", stockId, currentApiPeriod);
+                hasMoreDataFromApi = false;
+                continue;
+            }
+
+            // 2. DTO를 Entity로 변환
+            List<StockPriceHistory> entitiesToSave = dtoList.stream()
+                    .map(dto -> dto.toEntity(stockId))
+                    .collect(Collectors.toList());
+
+            // 3. saveAll
+            try {
+                stockPriceHistoryRepository.saveAll(entitiesToSave);
+                System.out.println("총 " + entitiesToSave.size() + "개의 주가 이력 데이터 저장 완료.");
+            } catch (Exception e) {
+                System.err.println("주가 이력 데이터 저장 중 오류 발생: " + e.getMessage());
+                e.printStackTrace(); // 상세한 스택 트레이스 출력
+                // 필요하다면 예외를 다시 던지거나 특정 예외로 변환
+                throw new RuntimeException("데이터베이스 저장 실패", e);
+            }
+
+            // 4. 다음 기간 계산 (가장 오래된 날짜 - 1일)
+            // DB에서 stockId에 해당하는 가장 오래된 거래일 조회
+            String oldestTradeDateStr = stockPriceHistoryRepository.findOldestTradeDateByStockId(stockId);
+
+            if (oldestTradeDateStr != null) {
+                // 문자열 → LocalDate 변환 (형식: "yyyyMMdd")
+                LocalDate oldestDateInDb = LocalDate.parse(
+                        oldestTradeDateStr,
+                        DateTimeFormatter.BASIC_ISO_DATE // "yyyyMMdd" 형식 지원
+                );
+
+                // 다음 기간 계산: 가장 오래된 거래일 - 1일
+                LocalDate nextPeriodDate = oldestDateInDb.minusDays(1);
+                currentApiPeriod = nextPeriodDate.format(DateTimeFormatter.BASIC_ISO_DATE);
+
+                // 종료 조건: 계산된 날짜가 목표일 이전인 경우
+                if (nextPeriodDate.isBefore(LAST_TARGET_DATE)) {
+                    hasMoreDataFromApi = false;
+                }
+            } else {
+                // 조회 결과가 null인 경우 (저장된 데이터 없음)
+                log.error("DB에서 가장 오래된 거래일 조회 실패. stockId: {}", stockId);
+                hasMoreDataFromApi = false;
+            }
+
+        } while (hasMoreDataFromApi);
     }
 }
+
+

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
@@ -1,0 +1,97 @@
+package com.project.stock.investory.mainData.service;
+
+import com.project.stock.investory.mainData.dto.StockPriceHistoryDto;
+import com.project.stock.investory.mainData.entity.StockPriceHistory;
+import com.project.stock.investory.mainData.repository.StockPriceHistoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+public class StockPriceSaveService {
+
+    private final StockPriceHistoryRepository stockPriceHistoryRepository;
+
+    @Autowired
+    public StockPriceSaveService(StockPriceHistoryRepository stockPriceHistoryRepository) {
+        this.stockPriceHistoryRepository = stockPriceHistoryRepository;
+    }
+
+    /**
+     * 주가 이력 DTO 리스트를 받아 DB에 저장
+     *
+     * @param dtoList 주가 이력 DTO 리스트
+     * @param stockId 저장할 종목코드 (외래키)
+     */
+    @Transactional // 모든 저장이 하나의 트랜잭션으로 묶이도록 합니다. (중요!)
+    public void saveAll(List<StockPriceHistoryDto> dtoList, String stockId) {
+        if (dtoList == null || dtoList.isEmpty()) {
+            System.out.println("저장할 주가 이력 데이터가 없습니다.");
+            return;
+        }
+
+        List<StockPriceHistory> entitiesToSave = dtoList.stream()
+                .map(dto -> convertToEntity(dto, stockId)) // DTO를 Entity로 변환
+                .collect(java.util.stream.Collectors.toList());
+
+        try {
+            stockPriceHistoryRepository.saveAll(entitiesToSave);
+            System.out.println("총 " + entitiesToSave.size() + "개의 주가 이력 데이터 저장 완료.");
+        } catch (Exception e) {
+            System.err.println("주가 이력 데이터 저장 중 오류 발생: " + e.getMessage());
+            e.printStackTrace(); // 상세한 스택 트레이스 출력
+            // 필요하다면 예외를 다시 던지거나 특정 예외로 변환
+            throw new RuntimeException("데이터베이스 저장 실패", e);
+        }
+    }
+
+    /**
+     * StockPriceHistoryDto를 StockPriceHistory Entity로 변환
+     */
+    private StockPriceHistory convertToEntity(StockPriceHistoryDto dto, String stockId) {
+        // 날짜 형식 지정: "YYYYMMDD"
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        return StockPriceHistory.builder()
+                .stockId(stockId) // 컨트롤러에서 받은 stockId 사용
+                .tradeDate(LocalDate.parse(dto.getStckBsopDate(), formatter)) // String -> LocalDate 파싱
+                // 가격 정보는 String으로 오므로 Integer로 변환, 실패할 경우 0 또는 null 처리
+                .openPrice(parseInteger(dto.getStckOprc()))
+                .closePrice(parseInteger(dto.getStckClpr()))
+                .highPrice(parseInteger(dto.getStckHgpr()))
+                .lowPrice(parseInteger(dto.getStckLwpr()))
+                // 거래량은 Long으로 변환
+                .volume(parseLong(dto.getAcmlVol()))
+                .build();
+    }
+
+    // String을 Integer로 안전하게 파싱하는 헬퍼 메서드
+    private Integer parseInteger(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null; // 또는 0 (요구사항에 따라)
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            System.err.println("Integer 파싱 오류: " + value);
+            return null; // 또는 0
+        }
+    }
+
+    // String을 Long으로 안전하게 파싱하는 헬퍼 메서드
+    private Long parseLong(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null; // 또는 0L (요구사항에 따라)
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            System.err.println("Long 파싱 오류: " + value);
+            return null; // 또는 0L
+        }
+    }
+}

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
@@ -59,21 +59,20 @@ public class StockPriceSaveService {
     public void saveAllTicker(String period) {
         List<RankDto> rankData = rankService.getRankData("5").block();
         int i = 0;
-
-        System.out.println("실행 start");
         long start = System.currentTimeMillis();
         if (rankData != null) {
             for (RankDto dto : rankData) {
 
                 String stockId = dto.getCode();
-                log.info("번호: {}, 종목: {}, 기준일자: {}", i, stockId, period);
                 i++;
+                log.info("번호: {}, 종목: {}, 기준일자: {}", i, stockId, period);
+
 
                 saveAll(stockId, period);
 
                 // sleep
                 try {
-                    Thread.sleep(1000);
+                    Thread.sleep(1234);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     e.printStackTrace();
@@ -82,7 +81,7 @@ public class StockPriceSaveService {
         } // end if
 
         long end = System.currentTimeMillis();
-        System.out.println("실행 시간(ms): " + (end - start));
+        log.info("elapsed all time(ms): {}", (end - start));
     }
 
 
@@ -90,12 +89,14 @@ public class StockPriceSaveService {
     @Transactional
     public void saveAll(String stockId, String period) {
 
+        long start = System.currentTimeMillis();
+
         // API 조회를 시작할 현재 기간 (초기값은 initialPeriod)
         String currentApiPeriod = period;
 
         // 목표로 하는 최종 날짜 (2022년 1월 1일)
         // LocalDate.of(YYYY, MM, DD) 형태로 직접 LocalDate 객체를 생성합니다.
-        final LocalDate LAST_TARGET_DATE = LocalDate.of(2022, 1, 1);
+        final LocalDate LAST_TARGET_DATE = LocalDate.of(2010, 1, 1);
 
         boolean hasMoreDataFromApi = true; // API에서 더 가져올 데이터가 있는지 여부
 
@@ -160,6 +161,9 @@ public class StockPriceSaveService {
                 log.error("DB에서 가장 오래된 거래일 조회 실패. stockId: {}", stockId);
                 hasMoreDataFromApi = false;
             }
+
+            long end = System.currentTimeMillis();
+            log.info("elapsed time(ms): {}", (end - start));
 
         } while (hasMoreDataFromApi);
     }


### PR DESCRIPTION
## 개요 
- KIS API로부터 주가 데이터를 받아오는 **저장 API**를 구현하고,
- 과거 데이터 저장 시 효율성과 정확도를 개선했습니다.

---

## 주요 변경 사항 
1. `StockPriceHistoryController`, `StockPriceHistoryService` 구현
2. KIS API 응답 기반으로 `StockPriceHistory` 엔티티 저장
3. 저장 시 **수정주가(adjusted price)** 기준으로 처리
4. 과거 데이터 요청 날짜 포맷 및 구간 설정 로직 추가
5. 데이터 저장 시간 로그로 측정 (속도 확인 목적)
6. 필요없는 부분 주석 처리 및 리팩토링

---
## 테스트 및 검증 
- 20080407~20250701  주가 7만 건 이상 저장 성공
elapsed all time(ms): 1114308 = **18분 34.308초**
---

## 기타 참고 사항 
- 저장 속도 개선을 위해 추후 batch insert 또는 비동기 처리 고려 가능
- scheduler활용하여 어제 종가 데이터 받아오는 로직 추가 예정 
- 동일 데이터 중복 저장 방지 로직 추가 예쩡 
- Redis 캐싱 또는 조회 최적화는 별도 PR로 분리 예정