### PR TITLE
feat: 관리자 페이지 유저/게시글/댓글 관리 기능 구현

### DIFF
--- a/src/main/java/com/project/stock/investory/admin/controller/AdminCommentController.java
+++ b/src/main/java/com/project/stock/investory/admin/controller/AdminCommentController.java
@@ -1,0 +1,52 @@
+package com.project.stock.investory.admin.controller;
+
+import com.project.stock.investory.admin.dto.AdminCommentResponseDto;
+import com.project.stock.investory.admin.dto.AdminCommentUpdateRequestDto;
+import com.project.stock.investory.admin.service.AdminCommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/comments")
+@RequiredArgsConstructor
+public class AdminCommentController {
+
+    private final AdminCommentService adminCommentService;
+
+    @Operation(summary = "관리자 - 전체 댓글 목록 조회")
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<AdminCommentResponseDto> getAllComments() {
+        return adminCommentService.getAllComments();
+    }
+
+    @Operation(summary = "관리자 - 댓글 상세 조회")
+    @GetMapping("/{commentId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public AdminCommentResponseDto getCommentById(@PathVariable Long commentId) {
+        return adminCommentService.getCommentById(commentId);
+    }
+
+    @Operation(summary = "관리자 - 댓글 삭제")
+    @DeleteMapping("/{commentId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public void deleteComment(@PathVariable Long commentId) {
+        adminCommentService.deleteComment(commentId);
+    }
+
+    @Operation(summary = "관리자 - 댓글 수정 (내용만 수정 가능)")
+    @PatchMapping("/{commentId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<AdminCommentResponseDto> updateComment(
+            @PathVariable Long commentId,
+            @RequestBody AdminCommentUpdateRequestDto dto
+    ) {
+        AdminCommentResponseDto updated = adminCommentService.updateComment(commentId, dto.getContent());
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/project/stock/investory/admin/controller/AdminPostController.java
+++ b/src/main/java/com/project/stock/investory/admin/controller/AdminPostController.java
@@ -1,0 +1,61 @@
+package com.project.stock.investory.admin.controller;
+
+import com.project.stock.investory.admin.dto.AdminPostResponseDto;
+import com.project.stock.investory.post.dto.PostRequestDto;
+import com.project.stock.investory.post.dto.PostWithAuthorDto;
+import com.project.stock.investory.admin.service.AdminPostService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/posts")
+public class AdminPostController {
+
+    private final AdminPostService adminPostService;
+
+    @Operation(summary = "관리자 - 전체 게시글 목록 조회")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public ResponseEntity<List<AdminPostResponseDto>> getAllPosts() {
+        List<AdminPostResponseDto> posts = adminPostService.getAllPosts();
+        return ResponseEntity.ok(posts);
+    }
+
+    @Operation(summary = "관리자 - 게시글 상세 조회")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostWithAuthorDto> getPostById(@PathVariable Long postId) {
+        PostWithAuthorDto post = adminPostService.getPostById(postId);
+        return ResponseEntity.ok(post);
+    }
+
+    @Operation(summary = "관리자 - 게시글 삭제")
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePostById(@PathVariable Long postId) {
+        adminPostService.deletePostById(postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "관리자 - 게시글 수정 (제목, 내용만 수정)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PatchMapping("/{postId}")
+    public ResponseEntity<PostWithAuthorDto> updatePostById(
+            @PathVariable Long postId,
+            @RequestBody PostRequestDto request) {
+
+        PostWithAuthorDto updatedPost = adminPostService.updatePostById(
+                postId,
+                request.getTitle(),
+                request.getContent()
+        );
+        return ResponseEntity.ok(updatedPost);
+    }
+
+}

--- a/src/main/java/com/project/stock/investory/admin/controller/AdminUserController.java
+++ b/src/main/java/com/project/stock/investory/admin/controller/AdminUserController.java
@@ -1,0 +1,48 @@
+package com.project.stock.investory.admin.controller;
+
+import com.project.stock.investory.admin.dto.AdminUserResponseDto;
+import com.project.stock.investory.admin.dto.AdminUserUpdateRequestDto;
+import com.project.stock.investory.admin.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<AdminUserResponseDto> getAllUsers() {
+        return adminUserService.getAllUsers();
+    }
+
+    @GetMapping("/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public AdminUserResponseDto getUserById(@PathVariable Long userId) {
+        return adminUserService.getUserById(userId);
+    }
+
+    @PatchMapping("/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public AdminUserResponseDto updateUser(
+            @PathVariable Long userId,
+            @RequestBody AdminUserUpdateRequestDto requestDto
+    ) {
+        return adminUserService.updateUser(userId, requestDto);
+    }
+
+    @DeleteMapping("/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public void deleteUser(@PathVariable Long userId) {
+        adminUserService.deleteUser(userId);
+    }
+
+
+}
+

--- a/src/main/java/com/project/stock/investory/admin/dto/AdminCommentResponseDto.java
+++ b/src/main/java/com/project/stock/investory/admin/dto/AdminCommentResponseDto.java
@@ -1,0 +1,19 @@
+package com.project.stock.investory.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminCommentResponseDto {
+    private Long commentId;
+    private Long postId;
+    private String postTitle;
+    private Long userId;
+    private String userName;
+    private String content;
+    private Integer likeCount;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/project/stock/investory/admin/dto/AdminCommentUpdateRequestDto.java
+++ b/src/main/java/com/project/stock/investory/admin/dto/AdminCommentUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package com.project.stock.investory.admin.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminCommentUpdateRequestDto {
+    private String content;
+}

--- a/src/main/java/com/project/stock/investory/admin/dto/AdminPostResponseDto.java
+++ b/src/main/java/com/project/stock/investory/admin/dto/AdminPostResponseDto.java
@@ -1,0 +1,19 @@
+package com.project.stock.investory.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminPostResponseDto {
+    private Long postId;
+    private String title;
+    private String authorName;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/project/stock/investory/admin/dto/AdminUserResponseDto.java
+++ b/src/main/java/com/project/stock/investory/admin/dto/AdminUserResponseDto.java
@@ -1,0 +1,30 @@
+package com.project.stock.investory.admin.dto;
+
+import com.project.stock.investory.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminUserResponseDto {
+    private Long userId;
+    private String email;
+    private String name;
+    private String phone;
+    private String role;
+    private LocalDateTime createdAt;
+
+    public static AdminUserResponseDto fromEntity(User user) {
+        return AdminUserResponseDto.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .phone(user.getPhone())
+                .role(user.getRole().name())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/project/stock/investory/admin/dto/AdminUserUpdateRequestDto.java
+++ b/src/main/java/com/project/stock/investory/admin/dto/AdminUserUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.project.stock.investory.admin.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminUserUpdateRequestDto {
+    private String name;
+    private String phone;
+    private String role;
+}

--- a/src/main/java/com/project/stock/investory/admin/service/AdminCommentService.java
+++ b/src/main/java/com/project/stock/investory/admin/service/AdminCommentService.java
@@ -1,0 +1,65 @@
+package com.project.stock.investory.admin.service;
+
+import com.project.stock.investory.admin.dto.AdminCommentResponseDto;
+import com.project.stock.investory.comment.model.Comment;
+import com.project.stock.investory.comment.repository.CommentRepository;
+import com.project.stock.investory.post.entity.Post;
+import com.project.stock.investory.post.repository.PostRepository;
+import com.project.stock.investory.user.entity.User;
+import com.project.stock.investory.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCommentService {
+
+    private final CommentRepository commentRepository;
+
+    public List<AdminCommentResponseDto> getAllComments() {
+        return commentRepository.findAll().stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    public AdminCommentResponseDto getCommentById(Long commentId) {
+        Comment comment = commentRepository.findByCommentId(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+        return toDto(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = commentRepository.findByCommentId(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+        commentRepository.delete(comment);
+    }
+
+    @Transactional
+    public AdminCommentResponseDto updateComment(Long commentId, String content) {
+        Comment comment = commentRepository.findByCommentId(commentId)
+                .orElseThrow(() -> new RuntimeException("댓글을 찾을 수 없습니다."));
+        comment.updateComment(content);
+        return toDto(comment);
+    }
+
+    private AdminCommentResponseDto toDto(Comment comment) {
+        Post post = comment.getPost();
+        User user = comment.getUser();
+
+        return AdminCommentResponseDto.builder()
+                .commentId(comment.getCommentId())
+                .postId(post.getPostId())
+                .postTitle(post.getTitle())
+                .userId(user.getUserId())
+                .userName(user.getName())
+                .content(comment.getContent())
+                .likeCount(comment.getLikeCount())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/project/stock/investory/admin/service/AdminPostService.java
+++ b/src/main/java/com/project/stock/investory/admin/service/AdminPostService.java
@@ -1,0 +1,52 @@
+package com.project.stock.investory.admin.service;
+
+import com.project.stock.investory.admin.dto.AdminPostResponseDto;
+import com.project.stock.investory.post.dto.PostWithAuthorDto;
+import com.project.stock.investory.post.entity.Post;
+import com.project.stock.investory.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPostService {
+
+    private final PostRepository postRepository;
+
+    public List<AdminPostResponseDto> getAllPosts() {
+        return postRepository.findAllAdminPostsWithAuthor();
+    }
+
+    @Transactional(readOnly = true)
+    public PostWithAuthorDto getPostById(Long postId) {
+        return postRepository.findPostWithAuthorById(postId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다.")); // 추후 예외클래스 추가 예정
+    }
+
+    @Transactional
+    public void deletePostById(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+        postRepository.delete(post);
+    }
+
+    @Transactional
+    public PostWithAuthorDto updatePostById(Long postId, String title, String content) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        post.setTitle(title);
+        post.setContent(content);
+        post.setUpdatedAt(LocalDateTime.now());
+
+        return postRepository.findPostWithAuthorById(postId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+    }
+
+}
+

--- a/src/main/java/com/project/stock/investory/admin/service/AdminUserService.java
+++ b/src/main/java/com/project/stock/investory/admin/service/AdminUserService.java
@@ -1,0 +1,80 @@
+package com.project.stock.investory.admin.service;
+
+import com.project.stock.investory.admin.dto.AdminUserResponseDto;
+import com.project.stock.investory.admin.dto.AdminUserUpdateRequestDto;
+import com.project.stock.investory.stockAlertSetting.processor.StockPriceProcessor;
+import com.project.stock.investory.user.entity.User;
+import com.project.stock.investory.user.entity.enums.Role;
+import com.project.stock.investory.user.exception.InvalidRoleException;
+import com.project.stock.investory.user.exception.UserNotFoundException;
+import com.project.stock.investory.user.exception.UserWithdrawnException;
+import com.project.stock.investory.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+    private final StockPriceProcessor stockPriceProcessor;
+
+    public List<AdminUserResponseDto> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(AdminUserResponseDto::fromEntity)
+                .toList();
+    }
+
+    public AdminUserResponseDto getUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException());
+        return AdminUserResponseDto.fromEntity(user);
+    }
+
+    @Transactional
+    public AdminUserResponseDto updateUser(Long userId, AdminUserUpdateRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 이름 변경
+        if (dto.getName() != null && !dto.getName().isBlank()) {
+            user.updateInfo(dto.getName(), user.getPhone());
+        }
+
+        // 전화번호 변경
+        if (dto.getPhone() != null && !dto.getPhone().isBlank()) {
+            user.updateInfo(user.getName(), dto.getPhone());
+        }
+
+        // 권한 변경
+        if (dto.getRole() != null && !dto.getRole().isBlank()) {
+            try {
+                user.setRole(Role.valueOf(dto.getRole().toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                throw new InvalidRoleException();
+            }
+        }
+
+        return AdminUserResponseDto.fromEntity(user);
+    }
+
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (user.getDeletedAt() != null) {
+            throw new UserWithdrawnException();
+        }
+
+        user.withdraw();
+
+        // 캐시  제거
+        stockPriceProcessor.removeUserCache(userId);
+    }
+}
+

--- a/src/main/java/com/project/stock/investory/config/SecurityConfig.java
+++ b/src/main/java/com/project/stock/investory/config/SecurityConfig.java
@@ -72,6 +72,9 @@ public class SecurityConfig {
                         // 댓글 조회 GET 요청 전체 공개
                         .requestMatchers(HttpMethod.GET, "/post/**").permitAll()
 
+                        // 관리자는 ADMIN 권한만 접근 가능
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/project/stock/investory/post/repository/PostRepository.java
+++ b/src/main/java/com/project/stock/investory/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.project.stock.investory.post.repository;
 
+import com.project.stock.investory.admin.dto.AdminPostResponseDto;
 import com.project.stock.investory.post.dto.PostWithAuthorDto;
 import com.project.stock.investory.post.entity.Board;
 import com.project.stock.investory.post.entity.Post;
@@ -39,5 +40,28 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "FROM Post p, User u WHERE p.userId = u.userId AND p.postId = :postId")
     Optional<PostWithAuthorDto> findPostWithAuthorById(@Param("postId") Long postId);
 
+    @Query("""
+    SELECT new com.project.stock.investory.post.dto.PostWithAuthorDto(
+        p.postId,
+        p.title,
+        p.content,
+        u.name
+    )
+    FROM Post p
+    JOIN User u ON p.userId = u.userId
+""")
+    List<PostWithAuthorDto> findAllPostsWithAuthor();
+
+    @Query("""
+    SELECT new com.project.stock.investory.admin.dto.AdminPostResponseDto(
+        p.postId,
+        p.title,
+        u.name,
+        p.createdAt
+    )
+    FROM Post p
+    JOIN User u ON p.userId = u.userId
+""")
+    List<AdminPostResponseDto> findAllAdminPostsWithAuthor();
 }
 

--- a/src/main/java/com/project/stock/investory/security/CustomUserDetails.java
+++ b/src/main/java/com/project/stock/investory/security/CustomUserDetails.java
@@ -3,6 +3,7 @@ package com.project.stock.investory.security;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -15,11 +16,11 @@ public class CustomUserDetails implements UserDetails {
     private final Long userId;
     private final String email;
     private final String name;
+    private final String role;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // 모든 사용자 ROLE_USER만 부여
-        return Collections.singleton(() -> "ROLE_USER");
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + this.role));
     }
 
     @Override

--- a/src/main/java/com/project/stock/investory/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/stock/investory/security/filter/JwtAuthenticationFilter.java
@@ -45,9 +45,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     Long userId = jwtUtil.getUserIdFromToken(token);
                     String email = jwtUtil.getEmailFromToken(token);
                     String name = jwtUtil.getNameFromToken(token);
+                    String role = jwtUtil.getRoleFromToken(token);
 
                     // 4. CustomUserDetails 생성
-                    CustomUserDetails userDetails = new CustomUserDetails(userId, email, name);
+                    CustomUserDetails userDetails = new CustomUserDetails(userId, email, name, role);
 
                     // 5. 인증 객체 생성 및 SecurityContext에 저장
                     UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/project/stock/investory/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/stock/investory/security/handler/OAuth2LoginSuccessHandler.java
@@ -35,7 +35,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtUtil.generateToken(
                 user.getUserId(),
                 user.getEmail(),
-                user.getName()
+                user.getName(),
+                user.getRole().name()
         );
 
         // 소셜 로그인 성공 후 프론트엔드로 토큰 전달

--- a/src/main/java/com/project/stock/investory/security/jwt/JwtUtil.java
+++ b/src/main/java/com/project/stock/investory/security/jwt/JwtUtil.java
@@ -23,11 +23,12 @@ public class JwtUtil {
     }
 
     // 토큰 생성 (userId, email, name 포함)
-    public String generateToken(Long userId, String email, String name) {
+    public String generateToken(Long userId, String email, String name, String role) {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId)) // 사용자 ID
                 .claim("email", email)              // 이메일 추가 정보
                 .claim("name", name)        // 이름 추가 정보
+                .claim("role", role)
                 .setIssuedAt(new Date())            // 발급 시간
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_MS)) // 만료 시간
                 .signWith(key, SignatureAlgorithm.HS256) // 서명
@@ -74,11 +75,12 @@ public class JwtUtil {
                 .getBody();
     }
 
-    public String generateRefreshToken(Long userId, String email, String name) {
+    public String generateRefreshToken(Long userId, String email, String name, String role) {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .claim("email", email)
                 .claim("name", name)
+                .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRATION_MS))
                 .signWith(key, SignatureAlgorithm.HS256)
@@ -88,4 +90,10 @@ public class JwtUtil {
     public boolean validateRefreshToken(String token) {
         return validateToken(token);
     }
+
+    public String getRoleFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("role", String.class);
+    }
+
 }

--- a/src/main/java/com/project/stock/investory/user/entity/User.java
+++ b/src/main/java/com/project/stock/investory/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.project.stock.investory.user.entity;
 
+import com.project.stock.investory.user.entity.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -49,6 +50,10 @@ public class User {
 
     private LocalDateTime deletedAt;  // 탈퇴일 (soft delete)
 
+    @Column(nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
     // 사용자 정보 수정 메서드
     public void updateInfo(String name, String phone) {
         this.name = name;
@@ -85,6 +90,10 @@ public class User {
 
     public void enableSocialLogin() {
         this.isSocial = 1;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
     }
 
 }

--- a/src/main/java/com/project/stock/investory/user/entity/enums/Role.java
+++ b/src/main/java/com/project/stock/investory/user/entity/enums/Role.java
@@ -1,0 +1,6 @@
+package com.project.stock.investory.user.entity.enums;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/project/stock/investory/user/exception/InvalidRoleException.java
+++ b/src/main/java/com/project/stock/investory/user/exception/InvalidRoleException.java
@@ -1,0 +1,10 @@
+package com.project.stock.investory.user.exception;
+
+import com.project.stock.investory.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRoleException extends BusinessException {
+    public InvalidRoleException() {
+        super("잘못된 권한 값입니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/project/stock/investory/user/service/UserService.java
+++ b/src/main/java/com/project/stock/investory/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.project.stock.investory.security.CustomUserDetails;
 import com.project.stock.investory.stockAlertSetting.processor.StockPriceProcessor;
 import com.project.stock.investory.user.dto.*;
 import com.project.stock.investory.user.entity.User;
+import com.project.stock.investory.user.entity.enums.Role;
 import com.project.stock.investory.user.exception.*;
 import com.project.stock.investory.user.repository.UserRepository;
 import com.project.stock.investory.security.jwt.JwtUtil;
@@ -88,6 +89,7 @@ public class UserService {
                 .name(request.getName())
                 .phone(request.getPhone())
                 .isSocial(0)
+                .role(Role.USER)
                 .build();
 
         // DB 저장
@@ -123,10 +125,12 @@ public class UserService {
         }
 
         // AccessToken 생성
-        String accessToken  = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName());
+        String accessToken  = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName(),
+                user.getRole().name());
 
         // RefreshToken 생성
-        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), user.getEmail(), user.getName());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), user.getEmail(), user.getName(),
+                user.getRole().name());
 
         user.updateRefreshToken(refreshToken);
         userRepository.save(user);
@@ -155,8 +159,10 @@ public class UserService {
             throw new InvalidRefreshTokenException();
         }
 
-        String newAccessToken = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName());
-        String newRefreshToken = jwtUtil.generateRefreshToken(user.getUserId(), user.getEmail(), user.getName());
+        String newAccessToken = jwtUtil.generateToken(user.getUserId(), user.getEmail(), user.getName(),
+                user.getRole().name());
+        String newRefreshToken = jwtUtil.generateRefreshToken(user.getUserId(), user.getEmail(), user.getName(),
+                user.getRole().name());
 
         user.updateRefreshToken(newRefreshToken);
 


### PR DESCRIPTION
###  작업 내용

- 관리자 페이지에서 유저 관리 기능 구현
  - 전체 목록 조회
  - 상세 조회 및 정보 수정
  - 탈퇴 처리

- 관리자 페이지에서 게시글 관리 기능 구현
  - 전체 목록 조회
  - 상세 조회 및 제목/내용 수정
  - 삭제 처리

- 관리자 페이지에서 댓글 관리 기능 구현
  - 전체 목록 조회
  - 상세 조회 및 내용 수정
  - 삭제 처리

###  참고 사항

- API 연동 완료 (스웨거 테스트 완료)