### PR TITLE
feat: 장 마감 후 주가 일별 데이터 자동 업데이트 스케줄러 추가

### DIFF
--- a/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
+++ b/src/main/java/com/project/stock/investory/mainData/controller/StockPriceController.java
@@ -39,11 +39,9 @@ public class StockPriceController {
 
 
     /**
-     * [price history api]
+     * [price history 조회]
      * 1. DB의 stock price history 조회
      * 2. 100영업일 데이터 가져오기
-     * 3. 데이터 save api
-     * 4. 티커별 데이터 save api
      */
     @Operation(summary = "DB의 stock price history 조회")
     @GetMapping("/{stockId}/history")
@@ -72,20 +70,29 @@ public class StockPriceController {
 
 
     // get 특정 종목 100개 가격 데이터
-    @Operation(summary = "get 특정 종목 100개 가격 데이터 ")
+    @Operation(summary = "get 특정 종목 100개 가격 데이터(Y, W, D")
     @GetMapping("/api/{stockId}/history")
     public List<StockPriceHistoryDto> getStockPriceHistory(
             @PathVariable String stockId,
-            @RequestParam String period
+            @RequestParam String period,
+            @RequestParam String periodDiv
     ) {
 
-        return stockPriceHistoryService.getStockPriceHistory(stockId, period);
+        return stockPriceHistoryService.getStockPriceHistory(stockId, period, periodDiv);
     }
 
 
+    /**
+     * [save]
+     * 1. 특정 종목 가격 데이터 조회 및 save"
+     * 2. 특정 종목의 오늘 주가(Daily) 데이터 저장
+     * 3. 여러 티커 가져와서 가격 데이터 저장
+     * 4. 시가총액 종목들의 일주일치 Daily 데이터 저장
+     */
+
     // 특정 종목 가격 데이터 조회 및 save
-    @Operation(summary = "특정 종목 가격 데이터 조회 및 save")
-    @PostMapping("/save/{stockId}")
+    @Operation(summary = "[TEST]특정 종목 가격 데이터 조회 및 save")
+    @PostMapping("/save/history/{stockId}")
     public ResponseEntity<String> fetchAndSaveStockPriceHistory(
             @PathVariable String stockId,
             @RequestParam String period
@@ -109,10 +116,20 @@ public class StockPriceController {
         }
     }
 
+    @Operation(summary = "[TEST]특정 종목의 오늘 주가(Daily) 데이터 저장")
+    @PostMapping("/save/daily/{stockId}")
+    public ResponseEntity<String> saveDailyPrice(@PathVariable String stockId) {
+        try {
+            stockPriceSaveService.saveDailyPrice(stockId);
+            return ResponseEntity.ok("주가 이력 데이터 저장 완료: " + stockId);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("저장 중 오류 발생: " + e.getMessage());
+        }
+    }
 
     // 여러 티커 가져와서 가격 데이터 저장
-    @Operation(summary = "여러 티커 가져와서 가격 데이터 저장")
-    @PostMapping("/save/all")
+    @Operation(summary = "[TEST]시가총액 100종목 가격 추이 데이터 저장(stock_id, trade_date unique적용)")
+    @PostMapping("/save/history")
     public String saveAllTicker(@RequestParam String period) {
         try {
             stockPriceSaveService.saveAllTicker(period);
@@ -120,6 +137,17 @@ public class StockPriceController {
         } catch (Exception e) {
             e.printStackTrace();
             return "저장 실패: " + e.getMessage();
+        }
+    }
+
+    @Operation(summary = "[TEST]시가총액 100종목들의 일주일치 Daily 데이터 저장(stock_id, trade_date unique적용)")
+    @PostMapping("/save/daily/ticker")
+    public ResponseEntity<String> saveDailyPriceTicker() {
+        try {
+            stockPriceSaveService.saveDailyPriceTicker();
+            return ResponseEntity.ok("시가총액 종목들의 Daily 데이터 저장 완료");
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("저장 중 오류 발생: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/project/stock/investory/mainData/entity/StockPriceHistory.java
+++ b/src/main/java/com/project/stock/investory/mainData/entity/StockPriceHistory.java
@@ -7,12 +7,17 @@ import java.time.LocalDate;
 
 
 @Entity
-@Table(name = "stock_price")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(
+        name = "stock_price",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_stock_trade_date", columnNames = {"stock_id", "trade_date"})
+        }
+)
 public class StockPriceHistory {
 
     @Id

--- a/src/main/java/com/project/stock/investory/mainData/repository/StockPriceHistoryRepository.java
+++ b/src/main/java/com/project/stock/investory/mainData/repository/StockPriceHistoryRepository.java
@@ -6,12 +6,23 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface StockPriceHistoryRepository extends JpaRepository<StockPriceHistory, Long> {
 
     // 특정 주식 ID (ticker)에 해당하는 모든 주가 이력 데이터 조회
     List<StockPriceHistory> findByStockId(String stockId);
+
+    // 특정 주식 ID (ticker)에 해당하는 모든 주가 이력 데이터를 최신 날짜 순으로 조회
+    List<StockPriceHistory> findByStockIdOrderByTradeDateDesc(String stockId);
+
+    // stockId와 tradeDate 함께 조회
+//    boolean existsByStockIdAndTradeDate(String stockId, LocalDate tradeDate); -> 11g버전 사용 불가
+    @Query(value = "SELECT COUNT(*) FROM stock_price " +
+            "WHERE stock_id = :stockId AND trade_date = :tradeDate", nativeQuery = true)
+    long countByStockIdAndTradeDateNative(@Param("stockId") String stockId,
+                                          @Param("tradeDate") LocalDate tradeDate);
 
     // 가장 과거의 거래일 조회 (네이티브 쿼리 사용)
     @Query(value = """
@@ -20,5 +31,6 @@ public interface StockPriceHistoryRepository extends JpaRepository<StockPriceHis
             WHERE stock_id = :stockId
             """, nativeQuery = true)
     String findOldestTradeDateByStockId(@Param("stockId") String stockId);
+
 
 }

--- a/src/main/java/com/project/stock/investory/mainData/scheduler/StockPriceHistoryScheduler.java
+++ b/src/main/java/com/project/stock/investory/mainData/scheduler/StockPriceHistoryScheduler.java
@@ -1,4 +1,22 @@
 package com.project.stock.investory.mainData.scheduler;
 
+import com.project.stock.investory.mainData.service.StockPriceSaveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class StockPriceHistoryScheduler {
+
+    @Autowired
+    private final StockPriceSaveService stockPriceSaveService;
+
+    // 장 마감 후 15시 50분에 현재 가격 데이터 일괄 업데이트
+    @Scheduled(cron = "00 50 15 * * *", zone = "Asia/Seoul")  // 장마감이후
+    public void saveDaily() {
+        stockPriceSaveService.saveDailyPriceTicker();
+
+    }
 }

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceHistoryService.java
@@ -48,7 +48,7 @@ public class StockPriceHistoryService {
     }
 
     /**
-     * 주식 가격 이력 조회
+     * 주식 가격 이력 조회(history)
      *
      * @param stockId 종목코드 (예: "005930")
      * @param period  기간 타입 (D:일봉, W:주봉, M:월봉)
@@ -56,7 +56,8 @@ public class StockPriceHistoryService {
      */
     public List<StockPriceHistoryDto> getStockPriceHistory(
             String stockId,
-            String period
+            String period,
+            String periodDiv
     ) {
         HttpHeaders headers = createHistoryHeaders();
 
@@ -67,7 +68,7 @@ public class StockPriceHistoryService {
                         .queryParam("fid_input_iscd", stockId)
                         .queryParam("fid_input_date_1", "20000101") // 가장 과거 데이터 하한 설정
                         .queryParam("fid_input_date_2", period)
-                        .queryParam("fid_period_div_code", "W") //  (D:일봉, W:주봉, M:월봉, Y:년봉)
+                        .queryParam("fid_period_div_code", periodDiv) //  (D:일봉, W:주봉, M:월봉, Y:년봉)
                         .queryParam("fid_org_adj_prc", "0") //  (0:수정주가 1:원주가)
                         .build())
                 .headers(httpHeaders -> httpHeaders.addAll(headers))

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
@@ -34,14 +34,13 @@ public class StockPriceSaveService {
         this.stockPriceHistoryService = stockPriceHistoryService;
         this.rankService = rankService;
         this.stockSaveService = stockSaveService;
-
     }
 
 
     // 특정 티커 주가 데이터 get
     public List<StockPriceHistoryResponseDto> getStockHistoryByTicker(String ticker) {
         // Repository 메서드 호출
-        List<StockPriceHistory> entities = stockPriceHistoryRepository.findByStockId(ticker);
+        List<StockPriceHistory> entities = stockPriceHistoryRepository.findByStockIdOrderByTradeDateDesc(ticker);
 
         // 엔티티 리스트를 DTO 리스트로 변환하여 반환
         return entities.stream()
@@ -51,6 +50,7 @@ public class StockPriceSaveService {
 
 
     /**
+     * [saveAll]
      * 1. 시가총액 기준 티커별 DB에 saveAllTicker
      * 2. 주가 이력 DTO 리스트를 받아 DB에 saveAll
      */
@@ -85,7 +85,7 @@ public class StockPriceSaveService {
     }
 
 
-    // 2. 주가 이력 DTO 리스트를 받아 DB에 saveAll
+    // 2. 주가 이력 DTO 리스트를 받아 DB에 saveAll - Weelky 데이터
     @Transactional
     public void saveAll(String stockId, String period) {
 
@@ -96,7 +96,7 @@ public class StockPriceSaveService {
 
         // 목표로 하는 최종 날짜 (2022년 1월 1일)
         // LocalDate.of(YYYY, MM, DD) 형태로 직접 LocalDate 객체를 생성합니다.
-        final LocalDate LAST_TARGET_DATE = LocalDate.of(2010, 1, 1);
+        final LocalDate LAST_TARGET_DATE = LocalDate.of(2000, 1, 1);
 
         boolean hasMoreDataFromApi = true; // API에서 더 가져올 데이터가 있는지 여부
 
@@ -107,7 +107,10 @@ public class StockPriceSaveService {
             try {
                 // 기간별 데이터 조회
                 log.info("종목: {}, 기준일자: {}", stockId, currentApiPeriod);
-                dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, currentApiPeriod);
+
+                // weekly로 저장
+                String periodDiv = "W";
+                dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, currentApiPeriod, periodDiv);
 
             } catch (Exception e) {
                 log.error("API 호출 중 오류 발생 (종목: {}, 기간: {}): {}", stockId, currentApiPeriod, e.getMessage(), e);
@@ -166,6 +169,84 @@ public class StockPriceSaveService {
             log.info("elapsed time(ms): {}", (end - start));
 
         } while (hasMoreDataFromApi);
+    }
+
+
+    /**
+     * Daily 데이터 Save
+     * 1. 한 종목 Daily 데이터 저장 - 일주일치
+     * 2. 시가총액 종목들 Daily Data(당일 데이터) 저장
+     */
+
+    // 1.한 종목 Daily 데이터 저장 - 일주일치 - stock_id, trade_date unique적용
+    @Transactional
+    public void saveDailyPrice(String stockId) {
+
+        // 오늘날짜기준 설정
+        final String todayStr = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+
+        // 1. API에서 데이터 받아오기
+        List<StockPriceHistoryDto> dtoList;
+        try {
+            // Daily 저장
+            String periodDiv = "D";
+            dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, todayStr, periodDiv);
+        } catch (Exception e) {
+            log.error("API 호출 중 오류 발생 (종목: {}, 기간: {}): {}", stockId, todayStr, e.getMessage(), e);
+            throw new RuntimeException("API 데이터 조회 실패", e);
+        }
+
+        // 2. DTO를 Entity로 변환
+        // -> 일주일치로 7개만 선택 (dtoList가 7개 미만이면 전체 반환)
+        List<StockPriceHistoryDto> dtoList_week = dtoList.stream()
+                .limit(7)
+                .collect(Collectors.toList());
+
+        List<StockPriceHistory> entitiesToSave = dtoList_week.stream()
+                .map(dto -> dto.toEntity(stockId))
+                .collect(Collectors.toList());
+
+        for (StockPriceHistory entity : entitiesToSave) {
+            long exist = stockPriceHistoryRepository.countByStockIdAndTradeDateNative(
+                    entity.getStockId(), entity.getTradeDate());
+
+            System.out.println("jjhdbug" + exist);
+            if (!(exist > 0)) {
+                stockPriceHistoryRepository.save(entity);
+            } else {
+                log.info("중복 데이터 생략: stock_id={}, trade_date={}", entity.getStockId(), entity.getTradeDate());
+            }
+        }
+
+    }
+
+    // 2. 시가총액 종목들 Daily Data(당일 데이터) 저장 - stock_id, trade_date unique적용
+    public void saveDailyPriceTicker() {
+        List<RankDto> rankData = rankService.getRankData("5").block();
+        int i = 0;
+        long start = System.currentTimeMillis();
+        if (rankData != null) {
+            for (RankDto dto : rankData) {
+                // 종목 코드
+                String stockId = dto.getCode();
+                i++;
+                log.info("번호: {}, 종목: {}, 기준일자: {}", i, stockId);
+
+                // 최근 일주일치 daily 가격 저장
+                saveDailyPrice(stockId);
+
+                // sleep
+                try {
+                    Thread.sleep(1234);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    e.printStackTrace();
+                }
+            }
+        } // end if
+
+        long end = System.currentTimeMillis();
+        log.info("elapsed all time(ms): {}", (end - start));
     }
 }
 

--- a/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
+++ b/src/main/java/com/project/stock/investory/mainData/service/StockPriceSaveService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -193,7 +194,7 @@ public class StockPriceSaveService {
             dtoList = stockPriceHistoryService.getStockPriceHistory(stockId, todayStr, periodDiv);
         } catch (Exception e) {
             log.error("API 호출 중 오류 발생 (종목: {}, 기간: {}): {}", stockId, todayStr, e.getMessage(), e);
-            throw new RuntimeException("API 데이터 조회 실패", e);
+            dtoList = Collections.emptyList();
         }
 
         // 2. DTO를 Entity로 변환
@@ -210,7 +211,6 @@ public class StockPriceSaveService {
             long exist = stockPriceHistoryRepository.countByStockIdAndTradeDateNative(
                     entity.getStockId(), entity.getTradeDate());
 
-            System.out.println("jjhdbug" + exist);
             if (!(exist > 0)) {
                 stockPriceHistoryRepository.save(entity);
             } else {

--- a/src/main/java/com/project/stock/investory/stockInfo/scheduler/StockScheduler.java
+++ b/src/main/java/com/project/stock/investory/stockInfo/scheduler/StockScheduler.java
@@ -14,8 +14,10 @@ public class StockScheduler {
     private final StockSaveService stockSaveService;
 
     // @Scheduled(cron = "*/30 * * * * *", zone = "Asia/Seoul") // 테스트용
-    // 매일 오전 9시 디비에 데이터 저장.
-    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")  //
+    // 매일 메인 데이터의 종목list 9시, 12시, 15시 디비에 데이터 update
+    @Scheduled(cron = "0 00 9 * * *", zone = "Asia/Seoul")  // 오전 9시 - 장시작
+    @Scheduled(cron = "0 00 12 * * *", zone = "Asia/Seoul") // 정오
+    @Scheduled(cron = "0 0 15 * * *", zone = "Asia/Seoul")  // 오후 3시 - 장마감
     public void saveDaily(){
         stockSaveService.saveVolumeRank();
         stockSaveService.saveTradingValueRank();


### PR DESCRIPTION
### 스케줄러 로직
- 실행 시점: **매일 15:50 (장 마감 후)**
- 업데이트 대상:
  - 기존: `weekly` 데이터 (20200101~20250630)
  - 신규: `daily` 데이터 (최근 일주일치)
- 저장 방식:
  - `stock_id` + `trade_date`를 복합키로 설정하여 중복 방지
  - 이미 저장된 데이터는 무시하고, 없는 데이터만 insert

### 예외 처리 개선
- 외부 API 호출 실패 또는 데이터 누락 시 **스케줄러 전체 실패 방지**
- 실패한 종목만 로그로 출력하고, 다음 루프로 계속 진행

---

## 데이터베이스 설계 
- `stock_price` 테이블
  - `PRIMARY KEY (stock_id, trade_date)` 복합키 설정
  - 중복 INSERT 방지 및 무결성 보장

---

## 테스트 및 검증
- 스케줄러 수동 실행 테스트 완료 (`@Scheduled(cron)` 조정)
- 중복 저장 없이 최근 일주일치만 정상 적재 확인
- API 에러 발생 시에도 스케줄 정상 동작 확인 (예외 catch)


